### PR TITLE
Upgrades Next 15.4.7->15.4.8 and  React 19.1.0->19.1.2 - Addresses CVE-2025-66478 and CVE-2025-55182

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -23,7 +23,7 @@
         "is-inside-container": "^1.0.0",
         "lucide-react": "^0.516.0",
         "next": "15.4.8",
-        "react": "19.1.0",
+        "react": "19.1.2",
         "react-dom": "19.1.0",
         "react-google-recaptcha": "^3.1.0",
         "react-icons": "^5.5.0",
@@ -6516,9 +6516,9 @@
       "license": "MIT"
     },
     "node_modules/react": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
-      "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+      "version": "19.1.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.1.2.tgz",
+      "integrity": "sha512-MdWVitvLbQULD+4DP8GYjZUrepGW7d+GQkNVqJEzNxE+e9WIa4egVFE/RDfVb1u9u/Jw7dNMmPB4IqxzbFYJ0w==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"

--- a/client/package.json
+++ b/client/package.json
@@ -30,7 +30,7 @@
     "is-inside-container": "^1.0.0",
     "lucide-react": "^0.516.0",
     "next": "15.4.8",
-    "react": "19.1.0",
+    "react": "19.1.2",
     "react-dom": "19.1.0",
     "react-google-recaptcha": "^3.1.0",
     "react-icons": "^5.5.0",


### PR DESCRIPTION
## Change Summary

**Upgrades Next 15.4.7->15.4.8 - Addresses CVE-2025-66478**.
**Upgrades React 19.1.0->19.1.2 - Addresses CVE-2025-55182**.

- Suggested by the Vercel team to upgrade to 15.4.8 and 19.1.2 to address the Remote Code Execution (RCE) vulnerability on React Server Components.
- Updated package.json and regenerated package-lock.json

### Extra Information

- [CVE Record](https://www.cve.org/CVERecord?id=CVE-2025-55182)

<img width="758" height="560" alt="image" src="https://github.com/user-attachments/assets/a6020b6d-0f1b-4bb2-a153-cd84cf242c9d" />
