### PR TITLE
Issue 85 add availability api endpoints

### DIFF
--- a/server/api/room/README.md
+++ b/server/api/room/README.md
@@ -106,7 +106,7 @@ http://localhost:8000/api/rooms/availability/?start_datetime=2026-01-19T12:00:00
 
 **GET** `/api/rooms/{id}/availability`
 
-Returns availabile slots for a single room. Slots returned will only include time later than now.
+Returns available slots for a single room. Slots returned will only include time later than now.
 
 ### Query Parameters:
 

--- a/server/api/room/tests.py
+++ b/server/api/room/tests.py
@@ -224,7 +224,7 @@ class AvailabilityAPITest(APITestCase):
 
         # Rooms with a recurrence rule (with count)
         self.room5 = Room.objects.create(
-            name="Meeting Room 4",
+            name="Meeting Room 5",
             location=self.loc1,
             capacity=12,
             start_datetime=timezone.make_aware(
@@ -313,7 +313,7 @@ class AvailabilityAPITest(APITestCase):
         # Check availability for next Monday to next Sunday
         response = self.client.get(
             f"/api/rooms/{self.room1.id}/availability/?start_date={next_monday.isoformat()}&end_date={next_sunday.isoformat()}")
-        print("\nAvailability Recurrrence Rules Response:")
+        print("\nAvailability Recurrence Rules Response:")
         print(response.content.decode())
         print()
 
@@ -337,7 +337,7 @@ class AvailabilityAPITest(APITestCase):
         # Check availability for next Monday to next Sunday
         response = self.client.get(
             f"/api/rooms/{self.room2.id}/availability/?start_date={next_monday.isoformat()}&end_date={next_sunday.isoformat()}")
-        print("\nAvailability No Reccurrence Rules Response:")
+        print("\nAvailability No Recurrence Rules Response:")
         print(response.content.decode())
         print()
 


### PR DESCRIPTION
## Change Summary
/rooms/{id}/availability: Returns availabile slots for a single room grouped by date
/rooms/availability: Returns paginated results of availability for multiple rooms (in the sense that whether they can be booked within a time range) => which I think it is useful after starting to implement #24 

### Change Form
**Fill this up (NA if not available). If a certain criteria is not met, can you please give a reason.**

- [X] The pull request title has an issue number
- [X] The change works by "Smoke testing" or quick testing
- [X] The change has tests
- [X] The change has documentation

## Other Information
Assumption:
- Start datetime and end datetime of a room must be on the same date.  (I guess a meeting room will not open from or until midnight)
- Slots returned will only include time later than now.
To do:
- handling EXDATE / RDATE based on #83

# Related issue
- Resolve #85