### PR TITLE
Issue 92 add booking detail page-Add Find My Booking flow with booking details, cancellation, and rebooking

### DIFF
--- a/client/src/app/find-my-booking/[bookingId]/detail-page.tsx
+++ b/client/src/app/find-my-booking/[bookingId]/detail-page.tsx
@@ -110,82 +110,88 @@ export default function DetailPage({
     <div className="mx-auto w-full max-w-6xl px-6 py-10">
       <div className="mt-8 grid gap-8 lg:grid-cols-[380px_1fr] lg:items-start lg:gap-12">
         {/* Left */}
-        <div className="rounded-lg border bg-white shadow-sm">
-          {normailisedRoom ? (
-            <RoomCard room={normailisedRoom} />
-          ) : (
-            <div className="p-6 text-sm text-muted-foreground">
-              Room information is not available.
-            </div>
-          )}
+        <div className="max-lg:flex max-lg:items-center max-lg:justify-center">
+          <div className="w-full max-w-[500px]">
+            {normailisedRoom ? (
+              <RoomCard room={normailisedRoom} />
+            ) : (
+              <div className="p-6 text-sm text-muted-foreground">
+                Room information is not available.
+              </div>
+            )}
+          </div>
         </div>
 
         {/* Right */}
-        <div className="rounded-lg border bg-white p-10 shadow-sm">
-          <div className="grid gap-y-3">
-            {[
-              ["Booking ID", booking.id],
-              ["Name", booking.visitor_name],
-              ["Email", booking.visitor_email],
-              ["Start", formatDateTime(booking.start_datetime)],
-              ["End", formatDateTime(booking.end_datetime)],
-              [
-                "Recurrence",
-                booking.recurrence_rule
-                  ? RRule.fromString(booking.recurrence_rule).toText()
-                  : "-",
-              ],
-              [
-                "Status",
-                <span
-                  key="status"
-                  className={cancelled ? "font-medium text-bloom-red" : ""}
+        <div className="max-lg:flex max-lg:items-center max-lg:justify-center">
+          <div className="w-full max-w-[500px] rounded-lg border bg-white p-10 shadow-sm">
+            <div className="grid gap-y-3">
+              {[
+                ["Booking ID", booking.id],
+                ["Name", booking.visitor_name],
+                ["Email", booking.visitor_email],
+                ["Start", formatDateTime(booking.start_datetime)],
+                ["End", formatDateTime(booking.end_datetime)],
+                [
+                  "Recurrence",
+                  booking.recurrence_rule
+                    ? RRule.fromString(booking.recurrence_rule).toText()
+                    : "-",
+                ],
+                [
+                  "Status",
+                  <span
+                    key="status"
+                    className={cancelled ? "font-medium text-bloom-red" : ""}
+                  >
+                    {booking.status}
+                  </span>,
+                ],
+              ].map(([label, value]) => (
+                <div
+                  key={label as string}
+                  className="grid grid-cols-1 sm:grid-cols-2 sm:gap-x-16"
                 >
-                  {booking.status}
-                </span>,
-              ],
-            ].map(([label, value]) => (
-              <div
-                key={label as string}
-                className="grid grid-cols-1 sm:grid-cols-2 sm:gap-x-16"
-              >
-                <div className="text-muted-foreground">{label}</div>
-                <div>{value}</div>
-              </div>
-            ))}
-          </div>
+                  <div className="text-muted-foreground">{label}</div>
+                  <div>{value}</div>
+                </div>
+              ))}
+            </div>
 
-          {/* Action Buttons */}
-          <div className="mt-10 flex flex-wrap gap-4">
-            {!cancelled ? (
-              <>
+            {/* Action Buttons */}
+            <div className="mt-10 flex flex-wrap gap-4">
+              {!cancelled ? (
+                <>
+                  <Button
+                    variant="confirm"
+                    onClick={() => {
+                      // to do: fix the routing
+                      const url = isAdminPage
+                        ? `/bookings/edit/${booking.id}`
+                        : `/book-room/edit/${booking.id}`;
+                      router.push(url);
+                    }}
+                  >
+                    Reschedule
+                  </Button>
+                  <Button
+                    variant="warning"
+                    onClick={() => setCancelDialogOpen(true)}
+                  >
+                    Cancel booking
+                  </Button>
+                </>
+              ) : (
                 <Button
                   variant="confirm"
-                  onClick={() => {
-                    // to do: fix the routing
-                    const url = isAdminPage
-                      ? `/bookings/edit/${booking.id}`
-                      : `/book-room/edit/${booking.id}`;
-                    router.push(url);
-                  }}
+                  onClick={() =>
+                    router.push(`/booking-room/${booking.room.id}`)
+                  }
                 >
-                  Reschedule
+                  Book again
                 </Button>
-                <Button
-                  variant="warning"
-                  onClick={() => setCancelDialogOpen(true)}
-                >
-                  Cancel booking
-                </Button>
-              </>
-            ) : (
-              <Button
-                variant="confirm"
-                onClick={() => router.push(`/booking-room/${booking.room.id}`)}
-              >
-                Book again
-              </Button>
-            )}
+              )}
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Change Summary
**Implemented the full Find My Booking user flow, allowing visitors to search
for bookings by email, view detailed booking and room information, cancel
confirmed bookings with a reason, and rebook via a “Book again” action.
The implementation integrates with existing backend APIs and introduces no
breaking backend changes.**

### Change Form
**Fill this up (NA if not available). If a certain criteria is not met, can you please give a reason.**

- [x] The pull request title has an issue number
- [x] The change works by "Smoke testing" or quick testing
  - Verified booking lookup, cancellation, status update, and rebooking
    navigation using test records in the database
- [ ] The change has tests  
  - Automated tests are not included; functionality has been validated through
    manual end-to-end testing due to time constraints
- [ ] The change has documentation  
  - No separate documentation added; feature behaviour is self-explanatory
    and demonstrated via screenshots

## Other Information
**Key implementation details for reviewers:**
- Booking cancellation is implemented via the existing
  `PATCH /bookings/:id/` endpoint using `visitor_email` and `cancel_reason`
- Backend serializer automatically transitions booking status to `CANCELLED`
- UI conditionally renders actions based on booking status
  (CONFIRMED vs CANCELLED)
- “Reschedule” button is intentionally disabled and reserved for future work
- Cancellation message input is currently UI-only and not persisted in backend
- Screenshots are attached to illustrate successful end-to-end behaviour**


# Related issue

- Resolve #92