### PR TITLE
Issue 125 Login page top padding fix & Adds show / hide password button

### DIFF
--- a/client/src/app/login/page.tsx
+++ b/client/src/app/login/page.tsx
@@ -188,6 +188,8 @@ export default function LoginPage() {
                 type="button"
                 className="pr-2"
                 onClick={() => setShowPassword(!showPassword)}
+                aria-label={showPassword ? "Hide password" : "Show password"}
+                aria-pressed={showPassword}
               >
                 {showPassword ? <Eye /> : <EyeClosed />}
               </button>


### PR DESCRIPTION
## Change Summary
Login top padding correctly centered and login password eye icon for show/unshow option completed.

<img width="726" height="737" alt="Screenshot 2026-01-31 at 3 57 53 pm" src="https://github.com/user-attachments/assets/5d0a0a7c-1605-4dc1-9a44-7f08aa025caf" />
<img width="727" height="737" alt="Screenshot 2026-01-31 at 3 57 47 pm" src="https://github.com/user-attachments/assets/b5266d59-f2c4-4c73-aa7c-4355a4564eb6" />

- [x] The pull request title has an issue number
- [x] The change works by "Smoke testing" or quick testing
- [x] The change has tests
- [x] The change has documentation
