### PR TITLE
Fix Time Options Issue

### DIFF
--- a/client/src/app/book-room/[room_id]/page.tsx
+++ b/client/src/app/book-room/[room_id]/page.tsx
@@ -6,6 +6,7 @@ import {
   endOfMonth,
   endOfWeek,
   format,
+  startOfDay,
   startOfMonth,
   startOfWeek,
 } from "date-fns";
@@ -664,17 +665,14 @@ function BookRoomForm() {
 
     const room_start = roomAvailability.start_datetime.getTime();
     const room_end = roomAvailability.end_datetime.getTime();
-    const start_of_day = new Date(
-      `${format(roomAvailability.start_datetime, "yyyy-MM-dd")}T00:00:00`,
-    );
-    const d = new Date(start_of_day);
+    const d = new Date(startOfDay(roomAvailability.start_datetime));
     while (d.getTime() <= room_end) {
       if (d.getTime() >= room_start) {
         const time = d.toTimeString().substring(0, 5);
         time_options.push({
           value: time,
           label: time,
-          disabled: !timeInTimeSlots(d.toTimeString().substring(0, 5), slots),
+          disabled: !timeInTimeSlots(time, slots),
         });
       }
       d.setTime(d.getTime() + slot_length);


### PR DESCRIPTION
## Change Summary
- Time options now start checking from 00:00 instead of the room's opening time ensuring times will only end in 00 or 30 rather than 30 minute intervals after the start time e.g. 8:47 for start time of 8:17