### PR TITLE
#197 Prevent calendar view to show bookers' names with no login.

### DIFF
--- a/server/api/booking/google_calendar/calendar_views.py
+++ b/server/api/booking/google_calendar/calendar_views.py
@@ -105,10 +105,16 @@ def get_room_calendar_events(request):
             events = events_result.get("items", [])
 
             # Transform events to match frontend expectations
+            is_auth = request.user.is_authenticated
             formatted_events = []
             for event in events:
+                raw_summary = event.get("summary", "")
+                if is_auth:
+                    summary = raw_summary
+                else:
+                    summary = raw_summary.split("-")[0].strip() if raw_summary else ""
                 formatted_events.append({
-                    "summary": event.get("summary", ""),
+                    "summary": summary,
                     "description": event.get("description", ""),
                     "start": event.get("start", {}),
                     "end": event.get("end", {}),


### PR DESCRIPTION
## Change Summary
Prevent calendar view to show bookers' names with no login.

### Change Form
**Fill this up (NA if not available). If a certain criteria is not met, can you please give a reason.**

- [X] The pull request title has an issue number
- [X] The change works by "Smoke testing" or quick testing
- [ ] The change has tests
- [ ] The change has documentation

## Other Information
When user is logging in (admin):
<img width="1280" height="767" alt="image" src="https://github.com/user-attachments/assets/8730507e-a485-4fe1-a533-0b5435b42509" />
No login (incognito):
<img width="1280" height="758" alt="image" src="https://github.com/user-attachments/assets/c2b7ec55-adb6-4421-9d5a-8a956dafa546" />


# Related issue

- Resolve #197